### PR TITLE
fix secor dropping messages

### DIFF
--- a/src/main/java/com/pinterest/secor/reader/KafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/KafkaMessageIterator.java
@@ -29,4 +29,6 @@ public interface KafkaMessageIterator {
     Message next();
     void init(SecorConfig config) throws UnknownHostException;
     void commit(TopicPartition topicPartition, long offset);
+
+    long getKafkaCommitedOffsetCount(TopicPartition topicPartition);
 }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -119,4 +119,8 @@ public class MessageReader {
     public void commit(TopicPartition topicPartition, long offset) {
         mKafkaMessageIterator.commit(topicPartition, offset);
     }
+
+    public long getCommitedOffsetCount(TopicPartition topicPartition) {
+        return mKafkaMessageIterator.getKafkaCommitedOffsetCount(topicPartition);
+    }
 }

--- a/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
@@ -144,7 +144,6 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator, Rebalanc
     @Override
     public void subscribe(RebalanceHandler handler, SecorConfig config) {
         ConsumerRebalanceListener reBalanceListener = new SecorConsumerRebalanceListener(mKafkaConsumer, mZookeeperConnector, getSkipZookeeperOffsetSeek(config), config.getNewConsumerAutoOffsetReset(), handler);
-        ;
 
         String[] subscribeList = config.getKafkaTopicList();
         if (subscribeList.length == 0 || Strings.isNullOrEmpty(subscribeList[0])) {
@@ -154,12 +153,20 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator, Rebalanc
         }
     }
 
-
     private boolean getSkipZookeeperOffsetSeek(SecorConfig config) {
-
         String dualCommitEnabled = config.getDualCommitEnabled();
         String offsetStorage = config.getOffsetsStorage();
-        return offsetStorage.equals("kafka") && dualCommitEnabled.equals("true");
+        return offsetStorage.equals("kafka") && dualCommitEnabled.equals("false");
+    }
 
+    @Override
+    public long getKafkaCommitedOffsetCount(final com.pinterest.secor.common.TopicPartition topicPartition) {
+        TopicPartition kafkaTopicPartition = new TopicPartition(topicPartition.getTopic(), topicPartition.getPartition());
+        OffsetAndMetadata offsetAndMetadata = mKafkaConsumer.committed(kafkaTopicPartition);
+        if (offsetAndMetadata != null) {
+            return offsetAndMetadata.offset();
+        } else {
+            return -1;
+        }
     }
 }

--- a/src/main/java/com/pinterest/secor/util/ProtobufUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ProtobufUtil.java
@@ -219,7 +219,7 @@ public class ProtobufUtil {
             while(null != (cause = result.getCause())  && (result != cause) ) {
                 result = cause;
             }
-            LOG.error("Unable to translate JSON string to protobuf message: {}. Assuming it's a protobuf message", result.getMessage());
+            LOG.warn("Unable to translate JSON string to protobuf message: {}. Assuming it's a protobuf message", result.getMessage());
         }
         return decodeProtobufMessage(topic, payload);
     }

--- a/src/main/java/com/pinterest/secor/util/ProtobufUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ProtobufUtil.java
@@ -211,8 +211,15 @@ public class ProtobufUtil {
                 return decodeJsonMessage(topic, payload);
             }
         } catch (InvalidProtocolBufferException e) {
-            //When trimming files, the Uploader will read and then decode messages in protobuf format
-            LOG.error("Unable to translate JSON string {} to protobuf message", new String(payload, Charsets.UTF_8));
+            // When trimming files, the Uploader will read and then decode messages in protobuf format
+           
+            // json exceptions are forwarded as invalidProtocolBufferException
+            Throwable cause = null; 
+            Throwable result = e;
+            while(null != (cause = result.getCause())  && (result != cause) ) {
+                result = cause;
+            }
+            LOG.error("Unable to translate JSON string to protobuf message: {}. Assuming it's a protobuf message", result.getMessage());
         }
         return decodeProtobufMessage(topic, payload);
     }

--- a/src/main/java/com/pinterest/secor/util/ProtobufUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ProtobufUtil.java
@@ -212,7 +212,7 @@ public class ProtobufUtil {
             }
         } catch (InvalidProtocolBufferException e) {
             //When trimming files, the Uploader will read and then decode messages in protobuf format
-            LOG.debug("Unable to translate JSON string {} to protobuf message", new String(payload, Charsets.UTF_8));
+            LOG.error("Unable to translate JSON string {} to protobuf message", new String(payload, Charsets.UTF_8));
         }
         return decodeProtobufMessage(topic, payload);
     }

--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -502,9 +502,12 @@ for fkey in ${S3_FILESYSTEMS}; do
         echo "Running tests for Message Type: ${MESSAGE_TYPE} and  ReaderWriter:${READER_WRITERS[${key}]} using filesystem: ${FILESYSTEM_TYPE}"
         if [ ${MESSAGE_TYPE} = "binary" ]; then
             post_stop_and_verity_test "kafka" "true"
-            post_stop_and_verity_test "kafka" "false"
             post_stop_and_verity_test "zookeeper" "true"
             post_stop_and_verity_test "zookeeper" "false"
+            if [[ "$MVN_PROFILE" == kafka-2.0.0 ]];then
+              post_stop_and_verity_test "kafka" "false"
+            fi
+
         else
             post_stop_and_verity_test "zookeeper" "false"
         fi


### PR DESCRIPTION
> Background: please read the update on https://remerge.atlassian.net/wiki/spaces/~528962913/pages/2162688008/Investigation+-+Inconsistency+on+Secor.

# Changeset

1. I ended up pulling https://github.com/pinterest/secor/pull/1801 as it already implements what I was doing (i.e: read offset consistently). Also, it adds a failfast on invalid config that could be useful for the future. How this is useful is described in the diff.
2. Changed logging level / corrected log msgs.

Although not needed, i think it's better to remove dual commit. I've raised https://github.com/remerge/chef.new/pull/821 for that.