### PR TITLE
Introduce HdfsRemergeUploadManager to handler HDFS nodes failover

### DIFF
--- a/src/main/java/com/pinterest/secor/uploader/HdfsRemergeUploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/HdfsRemergeUploadManager.java
@@ -1,0 +1,67 @@
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.LogFilePath;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.util.FileUtil;
+import org.apache.hadoop.ipc.StandbyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Manages uploads to S3 using the Hadoop API.
+ */
+public class HdfsRemergeUploadManager extends UploadManager {
+    private static final Logger LOG = LoggerFactory.getLogger(HdfsRemergeUploadManager.class);
+
+    protected static final ExecutorService executor = Executors.newFixedThreadPool(256);
+
+    public HdfsRemergeUploadManager(SecorConfig config) {
+        super(config);
+    }
+
+    private String[] getResolvedRemoteDestinations(LogFilePath localPath) throws Exception {
+        final String prefix = FileUtil.getPrefix(localPath.getTopic(), mConfig);
+        final LogFilePath path = localPath.withPrefix(prefix);
+        final String pathTemplate = path.getLogFilePath();
+
+        final String[] nameNodes = mConfig.getStringArray("secor.remerge.hdfs.namenode.list");
+        final String[] resolved = new String[nameNodes.length];
+        for (int idx = 0; idx < nameNodes.length; idx++) {
+            resolved[idx] = pathTemplate.replace("${REMERGE_HDFS_NN}", nameNodes[idx]);
+        }
+
+        return resolved;
+    }
+
+    public Handle<?> upload(LogFilePath localPath) throws Exception {
+        final String localLogFilename = localPath.getLogFilePath();
+        final String[] resolvedDestinations = getResolvedRemoteDestinations(localPath);
+
+        final Future<?> f = executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                for (String destLogFilename : resolvedDestinations) {
+                    try {
+                        LOG.info("Uploading file {} to {}", localLogFilename, destLogFilename);
+                        FileUtil.moveToCloud(localLogFilename, destLogFilename);
+                        return;
+                    } catch (StandbyException e) {
+                        LOG.warn("Upload failed due name node failover", e);
+                        continue;
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                throw new RuntimeException("All possible destinations were unsuccessful");
+            }
+        });
+
+        return new FutureHandle(f);
+    }
+}


### PR DESCRIPTION
Manager is activated through update of `.properties` file:

```
secor.upload.manager.class=com.pinterest.secor.uploader.HadoopRemergeUploadManager

secor.remerge.hadoop.namenode.list=nn2,nn1
secor.s3.bucket=${REMERGE_HDFS_NN}.dw1.remerge.io:8020/bucket-name
```

This is a MVP.